### PR TITLE
Changing from gethostbyaddr to gethostbyname

### DIFF
--- a/daklib/config.py
+++ b/daklib/config.py
@@ -72,7 +72,7 @@ class Config(object):
 
         # Check whether our dak.conf was the real one or
         # just a pointer to our main one
-        res = socket.gethostbyaddr(socket.gethostname())
+        res = socket.gethostbyname(socket.gethostname())
         conffile = self.Cnf.get("Config::" + res[0] + "::DakConfig")
         if conffile:
             apt_pkg.read_config_file_isc(self.Cnf, conffile)


### PR DESCRIPTION
gethostname() was being used inside gethostbyaddr(). This is most likely to
fail, since gethostname() will return a host name not an ip address.

Changing it to gethostbyname() so the result of gethostname() can be used directly.

Signed-off-by: Carlos Manuel Duclos Vergara carlosduclosv@yahoo.com
