### PR TITLE
dakweb: /sha256sum_in_archive/<sha256sum> endpoint

### DIFF
--- a/dakweb/queries/source.py
+++ b/dakweb/queries/source.py
@@ -79,8 +79,8 @@ def file_in_archive(filepattern=None):
                         is % for zero, one or more characters, _ for a
                         single character match.
 
-    @rtype: Dictionary, empty if nothing matched.
-    @return: A dictionary of
+    @rtype: list of dictionaries
+    @return: Dictionaries made out of
              - filename
              - sha256sum
     """
@@ -101,6 +101,40 @@ def file_in_archive(filepattern=None):
     return json.dumps(ret)
 
 QueryRegister().register_path('/file_in_archive', file_in_archive)
+
+
+@bottle.route('/sha256sum_in_archive/<sha256sum>')
+def sha256sum_in_archive(sha256sum=None):
+    """
+    Check if files with matching sha256sums are known to the archive.
+
+    @since: June 2018
+
+    @type sha256sum: string
+    @param sha256sum: SHA256 sum of the file.
+
+    @rtype: list of dictionaries
+    @return: Dictionaries made out of
+             - filename
+             - sha256sum
+    """
+    if sha256sum is None:
+        return bottle.HTTPError(503, 'sha256sum not specified.')
+
+    s = DBConn().session()
+    q = s.query(PoolFile)
+    q = q.filter(PoolFile.sha256sum == sha256sum)
+    ret = []
+
+    for p in q:
+        ret.append({'filename':  p.filename,
+                    'sha256sum': p.sha256sum})
+
+    s.close()
+
+    return json.dumps(ret)
+
+QueryRegister().register_path('/sha256sum_in_archive', sha256sum_in_archive)
 
 
 @bottle.route('/sources_in_suite/<suite>')


### PR DESCRIPTION
This patch creates a new /sha256sum_in_archive/<sha256sum>
endpoint in dakweb. The endpoint allows for searching for
files with a marching sha256sum in the archive.

I have also taken the time to fix docstrings of file_in_archive
which wrongly indicated that the return type was a dictionary.

I have tested the query on mirror.ftp-master.debian.org.

I am currently building a tool that uses dakweb to look for files in the archive. While file_in_archive is useful, I already have the sha256sum of the files I am looking for so I would like to perform more exact queries.

EDIT: submitted as [Debian Bug #901256](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=901256)